### PR TITLE
Use correct example for RPC url

### DIFF
--- a/transaction-sender/README.md
+++ b/transaction-sender/README.md
@@ -5,3 +5,7 @@ How to use:
 ```sh
 $ python main.py
 ```
+
+NOTE: `rpc-url` in settings should be without protocol
+
+~~http://example.com:18332~~ -> `example.com:18332`

--- a/transaction-sender/settings.example.json
+++ b/transaction-sender/settings.example.json
@@ -1,5 +1,5 @@
 {
-  "rpc-url": "http://localhost:18332/",
+  "rpc-url": "localhost:18332",
   "rpc-user": "mempool",
   "rpc-password": "password",
   "pay-request-chunk-size": 10,


### PR DESCRIPTION
Transaction sender uses JSON-RPC where url should be http://user:password@host:port hwere host should be without protocol.This is not clear from example and readme